### PR TITLE
Revert "[Penify] Full Repo Documentation"

### DIFF
--- a/patterns/src/test/kotlin/Decorator.kt
+++ b/patterns/src/test/kotlin/Decorator.kt
@@ -96,39 +96,6 @@ class EnhancedCoffeeMachine(private val coffeeMachine: CoffeeMachine) : CoffeeMa
      * ```
      */
 class DecoratorTest {
-    /**
-     * Tests the functionality of the Decorator pattern by creating an instance of
-     * a normal coffee machine and wrapping it with an enhanced coffee machine.
-     *
-     * This method demonstrates the use of decorators to extend the behavior of
-     * the coffee machine without modifying its original implementation.
-     *
-     * The following behaviors are tested:
-     * - Non-overridden behavior: `makeSmallCoffee()` from the normal coffee machine.
-     * - Overridden behavior: `makeLargeCoffee()` from the enhanced coffee machine.
-     * - Extended behavior: `makeCoffeeWithMilk()` from the enhanced coffee machine.
-     *
-     * @throws IllegalArgumentException if the coffee size is invalid.
-     * @throws UnsupportedOperationException if the requested operation is not supported by the machine.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testCoffeeMachineDecorator() {
-     *     val normalMachine = NormalCoffeeMachine()
-     *     val enhancedMachine = EnhancedCoffeeMachine(normalMachine)
-     *
-     *     // Test non-overridden behavior
-     *     enhancedMachine.makeSmallCoffee() // Should make a small coffee
-     *
-     *     // Test overridden behavior
-     *     enhancedMachine.makeLargeCoffee() // Should make a large coffee with enhanced features
-     *
-     *     // Test extended behavior
-     *     enhancedMachine.makeCoffeeWithMilk() // Should make coffee with milk
-     * }
-     * ```
-     */
     @Test
     fun Decorator() {
         val normalMachine = NormalCoffeeMachine()

--- a/patterns/src/test/kotlin/ProtectionProxy.kt
+++ b/patterns/src/test/kotlin/ProtectionProxy.kt
@@ -71,38 +71,6 @@ class SecuredFile(private val normalFile: File) : File {
      * ```
      */
 class ProtectionProxyTest {
-    /**
-     * This test method demonstrates the use of a Protection Proxy pattern.
-     * It creates a secured file that wraps a normal file and manages access
-     * based on a password.
-     *
-     * The method performs the following actions:
-     * 1. Reads a file without a password.
-     * 2. Sets a password for the secured file.
-     * 3. Reads the file again, this time requiring the password.
-     *
-     * @throws SecurityException if an attempt is made to read the file without
-     *         providing the correct password.
-     * @throws IOException if there is an error reading the file.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testProtectionProxy() {
-     *     val securedFile = SecuredFile(NormalFile())
-     *     with(securedFile) {
-     *         // Reading without password
-     *         read("readme.md") // Should succeed
-     *
-     *         // Setting password
-     *         password = "secret"
-     *
-     *         // Reading with password
-     *         read("readme.md") // Should succeed if the password is correct
-     *     }
-     * }
-     * ```
-     */
     @Test
     fun `Protection Proxy`() {
         val securedFile = SecuredFile(NormalFile())


### PR DESCRIPTION
### **User description**
Reverts sunil-nvoyager/Design-Patterns-In-Kotlin#6


___

### **Description**
- This PR reverts the previous changes made to the documentation of the `DecoratorTest` and `ProtectionProxyTest` classes.
- Extensive documentation comments have been removed to streamline the test code.
- The changes aim to simplify the tests and focus on the core functionality without verbose comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Decorator.kt</strong><dd><code>Remove Documentation Comments from Decorator Test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

patterns/src/test/kotlin/Decorator.kt
<li>Removed extensive documentation comments from the <code>DecoratorTest</code> class.<br> <li> Simplified the test method for the decorator pattern.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/7/files#diff-8ae505f204f890f4d45f00e754d324efc1570bbdfd687ff8491c7fb51285185c">+0/-33</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProtectionProxy.kt</strong><dd><code>Remove Documentation Comments from Protection Proxy Test</code>&nbsp; </dd></summary>
<hr>

patterns/src/test/kotlin/ProtectionProxy.kt
<li>Removed detailed documentation comments from the <code>ProtectionProxyTest</code> <br>class.<br> <li> Simplified the test method for the protection proxy pattern.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/7/files#diff-9d68f04603c383feb2d4c0d00bdf73bf5103309742e2b3f52a4ba4272794372b">+0/-32</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

