### PR TITLE
Revert "[Penify] Full Repo Documentation"

### DIFF
--- a/patterns/src/test/kotlin/Decorator.kt
+++ b/patterns/src/test/kotlin/Decorator.kt
@@ -5,42 +5,8 @@ interface CoffeeMachine {
     fun makeLargeCoffee()
 }
 
-/**
- * Makes a small coffee and prints a message indicating that the process has started.
- *
- * This function is a simple implementation that simulates the action of making a small coffee.
- * It does not return any value but outputs a message to the console.
- *
- * @throws IllegalStateException if the coffee machine is not ready to make coffee.
- *
- * Example usage:
- * ```
- * val coffeeMachine = CoffeeMachine()
- * try {
- *     coffeeMachine.makeSmallCoffee()
- * } catch (e: IllegalStateException) {
- *     println("Cannot make coffee: ${e.message}")
- * }
- * ```
- */
 class NormalCoffeeMachine : CoffeeMachine {
     override fun makeSmallCoffee() = println("Normal: Making small coffee")
-/**
- * This method is responsible for making a large coffee.
- * It prints a message indicating that a large coffee is being made.
- *
- * @throws IllegalStateException if the coffee machine is not ready to make coffee.
- *
- * Example usage:
- * ```
- * val coffeeMachine = CoffeeMachine()
- * if (coffeeMachine.isReady()) {
- *     coffeeMachine.makeLargeCoffee()
- * } else {
- *     throw IllegalStateException("Coffee machine is not ready.")
- * }
- * ```
- */
 
     override fun makeLargeCoffee() = println("Normal: Making large coffee")
 }
@@ -65,36 +31,6 @@ class EnhancedCoffeeMachine(private val coffeeMachine: CoffeeMachine) : CoffeeMa
     }
 }
 
-    /**
-     * Tests the functionality of the Decorator pattern with coffee machines.
-     *
-     * This method demonstrates how an enhanced coffee machine can extend the behavior of a normal coffee machine.
-     * It showcases both the non-overridden and overridden methods, as well as additional functionalities provided
-     * by the decorator.
-     *
-     * The following behaviors are tested:
-     * - Making a small coffee using the normal behavior of the enhanced machine.
-     * - Making a large coffee using the overridden behavior of the enhanced machine.
-     * - Making coffee with milk using the extended behavior of the enhanced machine.
-     *
-     * @throws IllegalArgumentException if the coffee size is invalid.
-     * @throws UnsupportedOperationException if the requested operation is not supported by the machine.
-     *
-     * Example usage:
-     * ```
-     * val normalMachine = NormalCoffeeMachine()
-     * val enhancedMachine = EnhancedCoffeeMachine(normalMachine)
-     *
-     * // Non-overridden behavior
-     * enhancedMachine.makeSmallCoffee() // Should produce a small coffee
-     *
-     * // Overridden behavior
-     * enhancedMachine.makeLargeCoffee() // Should produce a large coffee with enhanced features
-     *
-     * // Extended behavior
-     * enhancedMachine.makeCoffeeWithMilk() // Should produce coffee with milk
-     * ```
-     */
 class DecoratorTest {
     @Test
     fun Decorator() {

--- a/patterns/src/test/kotlin/Facade.kt
+++ b/patterns/src/test/kotlin/Facade.kt
@@ -25,73 +25,16 @@ data class User(val login: String)
 class UserRepository {
 
     private val systemPreferences = ComplexSystemStore("/data/default.prefs")
-/**
- * Saves the login information of the specified user to the system preferences.
- *
- * This method stores the user's login under the key "USER_KEY" and commits the changes
- * to the system preferences. It is important to ensure that the user object is not null
- * before calling this method.
- *
- * @param user The User object containing the login information to be saved.
- * @throws IllegalArgumentException if the user parameter is null.
- * @throws IOException if there is an error while committing the changes to system preferences.
- *
- * @example
- * val user = User("john_doe")
- * try {
- *     save(user)
- *     println("User login saved successfully.")
- * } catch (e: IllegalArgumentException) {
- *     println("Error: ${e.message}")
- * } catch (e: IOException) {
- *     println("Error saving user login: ${e.message}")
- * }
- */
 
     fun save(user: User) {
         systemPreferences.store("USER_KEY", user.login)
         systemPreferences.commit()
     }
-/**
- * Retrieves the first user from the system preferences.
- *
- * This method reads the value associated with the key "USER_KEY" from the system preferences
- * and returns a `User` object initialized with that value.
- *
- * @return A `User` object representing the first user.
- * @throws IllegalArgumentException if the value retrieved from system preferences is null or empty,
- *         indicating that no user was found.
- *
- * @example
- * val user = findFirst()
- * println("The first user is: ${user.name}")
- */
 
     fun findFirst(): User = User(systemPreferences.read("USER_KEY"))
 }
 
 class FacadeTest {
-    /**
-     * This test method demonstrates the usage of the UserRepository class to save and retrieve a User object.
-     *
-     * It creates an instance of UserRepository, saves a User with the username "dbacinski",
-     * and then retrieves the first stored user from the repository. The retrieved user is printed to the console.
-     *
-     * @throws IllegalArgumentException if the user cannot be saved due to invalid data.
-     * @throws NoSuchElementException if no users are found in the repository when attempting to retrieve the first user.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testUserRepository() {
-     *     val userRepository = UserRepository()
-     *     val user = User("dbacinski")
-     *     userRepository.save(user)
-     *     val resultUser = userRepository.findFirst()
-     *     println("Found stored user: $resultUser")
-     * }
-     * ```
-     */
 
     @Test
     fun Facade() {

--- a/patterns/src/test/kotlin/FactoryMethod.kt
+++ b/patterns/src/test/kotlin/FactoryMethod.kt
@@ -26,31 +26,6 @@ object CurrencyFactory {
 }
 
 class FactoryMethodTest {
-    /**
-     * Tests the functionality of the CurrencyFactory to ensure it correctly
-     * returns the currency code for specified countries.
-     *
-     * This method retrieves the currency code for Greece and the USA,
-     * then asserts that the returned values match the expected currency codes.
-     *
-     * @throws IllegalArgumentException if the country provided does not have a corresponding currency.
-     * @throws NullPointerException if the country parameter is null.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testCurrencyFactory() {
-     *     val greeceCurrency = CurrencyFactory.currencyForCountry(Greece("")).code
-     *     println("Greece currency: $greeceCurrency") // Expected output: Greece currency: EUR
-     *
-     *     val usaCurrency = CurrencyFactory.currencyForCountry(Country.USA).code
-     *     println("USA currency: $usaCurrency") // Expected output: USA currency: USD
-     *
-     *     assertThat(greeceCurrency).isEqualTo("EUR")
-     *     assertThat(usaCurrency).isEqualTo("USD")
-     * }
-     * ```
-     */
 
     @Test
     fun FactoryMethod() {

--- a/patterns/src/test/kotlin/Listener.kt
+++ b/patterns/src/test/kotlin/Listener.kt
@@ -10,24 +10,6 @@ interface TextChangedListener {
 class PrintingTextChangedListener : TextChangedListener {
 
     var text = ""
-/**
- * Called when the text has changed.
- *
- * This method is triggered whenever the text content is modified. It receives the old text
- * and the new text as parameters, allowing for comparison and handling of the change.
- *
- * @param oldText The previous text before the change occurred.
- * @param newText The new text after the change has been made.
- *
- * @throws IllegalArgumentException if either oldText or newText is null.
- *
- * Example usage:
- * ```
- * override fun onTextChanged(oldText: String, newText: String) {
- *     text = "Text is changed: $oldText -> $newText"
- * }
- * ```
- */
 
     override fun onTextChanged(oldText: String, newText: String) {
         text = "Text is changed: $oldText -> $newText"
@@ -44,34 +26,6 @@ class TextView {
 }
 
 class ListenerTest {
-    /**
-     * Tests the functionality of the `PrintingTextChangedListener` by simulating text changes
-     * in a `TextView`. This method verifies that the listener correctly captures the text changes
-     * and asserts that the expected output matches the actual output.
-     *
-     * The test initializes a `PrintingTextChangedListener` and attaches it to a `TextView`.
-     * It then changes the text of the `TextView` twice, checking that the listener records
-     * the changes accurately.
-     *
-     * @throws IllegalStateException if the listener is not properly initialized or attached
-     *         to the TextView before text changes occur.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testTextChangeListener() {
-     *     val listener = PrintingTextChangedListener()
-     *     val textView = TextView().apply {
-     *         listeners.add(listener)
-     *     }
-     *     with(textView) {
-     *         text = "Hello"
-     *         text = "World"
-     *     }
-     *     assertThat(listener.text).isEqualTo("Text is changed: Hello -> World")
-     * }
-     * ```
-     */
 
     @Test
     fun Listener() {

--- a/patterns/src/test/kotlin/ProtectionProxy.kt
+++ b/patterns/src/test/kotlin/ProtectionProxy.kt
@@ -4,20 +4,6 @@ interface File {
     fun read(name: String)
 }
 
-/**
- * Reads the content of a file with the specified name and prints a message to the console.
- *
- * This method takes a file name as input and outputs a message indicating that the file is being read.
- *
- * @param name The name of the file to be read. This should be a valid file name.
- * @throws IllegalArgumentException if the provided file name is empty or null.
- *
- * Example usage:
- * ```
- * val fileName = "example.txt"
- * read(fileName) // Output: Reading file: example.txt
- * ```
- */
 class NormalFile : File {
     override fun read(name: String) = println("Reading file: $name")
 }
@@ -36,40 +22,6 @@ class SecuredFile(private val normalFile: File) : File {
     }
 }
 
-    /**
-     * This test method demonstrates the use of the Protection Proxy design pattern.
-     * It creates a secured file that wraps a normal file, allowing controlled access
-     * based on the provided password.
-     *
-     * The method performs the following actions:
-     * 1. It attempts to read a file named "readme.md" without a password.
-     * 2. It sets a password for the secured file.
-     * 3. It attempts to read the same file again after setting the password.
-     *
-     * @throws SecurityException if an attempt is made to read the file without the correct password.
-     * @throws IOException if there is an error reading the file.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testProtectionProxy() {
-     *     val securedFile = SecuredFile(NormalFile())
-     *     with(securedFile) {
-     *         // Attempt to read without password (should throw SecurityException)
-     *         try {
-     *             read("readme.md")
-     *         } catch (e: SecurityException) {
-     *             println("Caught expected SecurityException: ${e.message}")
-     *         }
-     *
-     *         // Set password and read again
-     *         password = "secret"
-     *         val content = read("readme.md")
-     *         println("File content: $content")
-     *     }
-     * }
-     * ```
-     */
 class ProtectionProxyTest {
     @Test
     fun `Protection Proxy`() {

--- a/patterns/src/test/kotlin/Singleton.kt
+++ b/patterns/src/test/kotlin/Singleton.kt
@@ -11,27 +11,6 @@ object PrinterDriver {
 }
 
 class SingletonTest {
-    /**
-     * This test method verifies the Singleton pattern implementation of the `PrinterDriver` class.
-     * It ensures that multiple calls to the `print()` method return the same instance of `PrinterDriver`.
-     *
-     * The test begins by printing a start message. It then calls the `print()` method twice,
-     * storing the results in `printerFirst` and `printerSecond`. Finally, it asserts that both
-     * instances are the same, confirming that the singleton behavior is maintained.
-     *
-     * @throws AssertionError if the instances are not the same, indicating that the singleton
-     *         pattern is not correctly implemented in the `PrinterDriver` class.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testSingletonBehavior() {
-     *     val printerFirst = PrinterDriver.print()
-     *     val printerSecond = PrinterDriver.print()
-     *     assertThat(printerFirst).isSameAs(printerSecond)
-     * }
-     * ```
-     */
 
     @Test
     fun Singleton() {

--- a/patterns/src/test/kotlin/State.kt
+++ b/patterns/src/test/kotlin/State.kt
@@ -24,47 +24,10 @@ class AuthorizationPresenter {
                 is Unauthorized -> "Unknown"
             }
         }
-/**
- * Logs in a user with the specified username.
- *
- * This function updates the application state to indicate that the user
- * has been authorized. It takes a username as a parameter and sets the
- * state to an instance of `Authorized` with the provided username.
- *
- * @param userName The username of the user to be logged in. Must not be empty.
- * @throws IllegalArgumentException if the provided username is empty.
- *
- * @example
- * // Example usage of loginUser function
- * try {
- *     loginUser("john_doe")
- * } catch (e: IllegalArgumentException) {
- *     println("Error: ${e.message}")
- * }
- */
 
     fun loginUser(userName: String) {
         state = Authorized(userName)
     }
-/**
- * Logs out the current user by changing the state to Unauthorized.
- *
- * This method updates the application's state to reflect that the user is no longer authenticated.
- * It is typically called when a user chooses to log out of the application.
- *
- * @throws IllegalStateException if the user is not currently logged in.
- *
- * ## Example
- * ```
- * // Assuming the user is logged in
- * try {
- *     logoutUser()
- *     println("User has been logged out successfully.")
- * } catch (e: IllegalStateException) {
- *     println("Error: ${e.message}")
- * }
- * ```
- */
 
     fun logoutUser() {
         state = Unauthorized
@@ -74,38 +37,6 @@ class AuthorizationPresenter {
 }
 
 class StateTest {
-    /**
-     * Tests the login and logout functionality of the AuthorizationPresenter class.
-     *
-     * This test verifies that a user can successfully log in with valid credentials,
-     * and that the state of the AuthorizationPresenter reflects the correct authorization status
-     * and username after login and logout operations.
-     *
-     * It performs the following steps:
-     * 1. Creates an instance of AuthorizationPresenter.
-     * 2. Logs in a user with the username "admin".
-     * 3. Asserts that the user is authorized and the username is correctly set.
-     * 4. Logs out the user.
-     * 5. Asserts that the user is no longer authorized and the username is reset to "Unknown".
-     *
-     * @throws IllegalArgumentException if the login credentials are invalid.
-     * @throws IllegalStateException if an operation is attempted on an unauthorized user.
-     *
-     * Example usage:
-     * ```
-     * @Test
-     * fun testAuthorization() {
-     *     val authorizationPresenter = AuthorizationPresenter()
-     *     authorizationPresenter.loginUser("admin")
-     *     assertThat(authorizationPresenter.isAuthorized).isEqualTo(true)
-     *     assertThat(authorizationPresenter.userName).isEqualTo("admin")
-     *
-     *     authorizationPresenter.logoutUser()
-     *     assertThat(authorizationPresenter.isAuthorized).isEqualTo(false)
-     *     assertThat(authorizationPresenter.userName).isEqualTo("Unknown")
-     * }
-     * ```
-     */
 
     @Test
     fun State() {

--- a/patterns/src/test/kotlin/Strategy.kt
+++ b/patterns/src/test/kotlin/Strategy.kt
@@ -11,27 +11,6 @@ val lowerCaseFormatter: (String) -> String = { it.toLowerCase() }
 val upperCaseFormatter = { it: String -> it.toUpperCase() }
 
 class StrategyTest {
-    /**
-     * Tests the functionality of various string formatting strategies using the Printer class.
-     *
-     * This test method demonstrates how to use different string formatters to print a given input string.
-     * It utilizes a lower case formatter, an upper case formatter, and a custom prefix formatter.
-     *
-     * @throws IllegalArgumentException if the input string is null or empty.
-     *
-     * Example usage:
-     * ```
-     * val inputString = "LOREM ipsum DOLOR sit amet"
-     * val lowerCasePrinter = Printer(lowerCaseFormatter)
-     * lowerCasePrinter.printString(inputString) // Output: "lorem ipsum dolor sit amet"
-     *
-     * val upperCasePrinter = Printer(upperCaseFormatter)
-     * upperCasePrinter.printString(inputString) // Output: "LOREM IPSUM DOLOR SIT AMET"
-     *
-     * val prefixPrinter = Printer { "Prefix: $it" }
-     * prefixPrinter.printString(inputString) // Output: "Prefix: LOREM ipsum DOLOR sit amet"
-     * ```
-     */
 
     @Test
     fun Strategy() {


### PR DESCRIPTION
### **User description**
Reverts sunil-nvoyager/Design-Patterns-In-Kotlin#5


___

### **Description**
This PR reverts the previous documentation changes made in the repository.
- Removed extensive documentation comments across multiple test files.
- Aimed to clean up the codebase by eliminating unnecessary comments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Decorator.kt</strong><dd><code>Remove documentation comments from Decorator pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/Decorator.kt
<li>Removed extensive documentation comments from <code>NormalCoffeeMachine</code> and <br><code>DecoratorTest</code>.<br> <li> Deleted method documentation for coffee-making functionalities.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-8ae505f204f890f4d45f00e754d324efc1570bbdfd687ff8491c7fb51285185c">+0/-64</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Facade.kt</strong><dd><code>Remove documentation comments from Facade pattern tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

patterns/src/test/kotlin/Facade.kt
<li>Removed documentation comments from <code>UserRepository</code> and <code>FacadeTest</code>.<br> <li> Deleted method documentation for user saving and retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-7818b2fbd60cddeba8f23eb61d577908bebaab8d0242f420f6658ed3b6179ce4">+0/-57</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>FactoryMethod.kt</strong><dd><code>Remove documentation comments from Factory Method pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/FactoryMethod.kt
<li>Removed documentation comments from <code>CurrencyFactory</code> and <br><code>FactoryMethodTest</code>.<br> <li> Deleted method documentation for currency retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-ddebd9cc8b7bedd1ea39953b583e880a426a957cf456730414c8f51f846d658d">+0/-25</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Listener.kt</strong><dd><code>Remove documentation comments from Listener pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/Listener.kt
<li>Removed documentation comments from <code>PrintingTextChangedListener</code> and <br><code>ListenerTest</code>.<br> <li> Deleted method documentation for text change handling.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-02b48441d1df5db50e42e95287aec04b88c2893c37ff76511176d0fb2283814d">+0/-46</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProtectionProxy.kt</strong><dd><code>Remove documentation comments from Protection Proxy pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/ProtectionProxy.kt
<li>Removed documentation comments from <code>NormalFile</code> and <br><code>ProtectionProxyTest</code>.<br> <li> Deleted method documentation for file reading.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-9d68f04603c383feb2d4c0d00bdf73bf5103309742e2b3f52a4ba4272794372b">+0/-48</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Singleton.kt</strong><dd><code>Remove documentation comments from Singleton pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/Singleton.kt
<li>Removed documentation comments from <code>PrinterDriver</code> and <code>SingletonTest</code>.<br> <li> Deleted method documentation for singleton behavior.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-4dd64adeab0f238ebb1fe197a6c6a8ce83b0f5fd05ae89ced6fef0c4ecc9ca71">+0/-21</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>State.kt</strong><dd><code>Remove documentation comments from State pattern tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

patterns/src/test/kotlin/State.kt
<li>Removed documentation comments from <code>AuthorizationPresenter</code> and <br><code>StateTest</code>.<br> <li> Deleted method documentation for login and logout functionalities.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-0a7096515344d2479087a10a1c58d450551ff4180e340ccd83d75ce54e5ba46e">+0/-69</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Strategy.kt</strong><dd><code>Remove documentation comments from Strategy pattern tests</code></dd></summary>
<hr>

patterns/src/test/kotlin/Strategy.kt
<li>Removed documentation comments from <code>StrategyTest</code>.<br> <li> Deleted method documentation for string formatting strategies.<br>


</details>


  </td>
  <td><a href="https://github.com/sunil-nvoyager/Design-Patterns-In-Kotlin/pull/8/files#diff-ee35cab52e02747880ec1f6fca5d7c866ab138c794ac6088cc1c6f293d20d4fa">+0/-21</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

